### PR TITLE
Encode version with zero values

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -212,7 +212,9 @@ func (e *Encoder) encode(rv reflect.Value, sd *structDesc) (err error) {
 					return
 				}
 
-				if isZero {
+				isVersion := f.name == "PROTOCOL_VERSION_MAJOR" || f.name == "PROTOCOL_VERSION_MINOR" || f.name == "PROTOCOL_VERSION"
+
+				if isZero && !isVersion {
 					continue
 				}
 			}


### PR DESCRIPTION
Before this change, version 1.0 was not encoded correctly (or at least
was not encoded in a way that some clients understand). Now zero values
will be encoded if they belong to one of the version fields.