### PR TITLE
Add opt-in KMIP 2.0 payload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ import (
 - Currently covered KMIP 2.0 operations:
   - Create
   - CreateKeyPair
+  - Get
   - Register
   - Locate
   - SetAttribute
+  - AdjustAttribute
+  - ReKey
+  - AddAttribute
+  - ModifyAttribute
+  - DeleteAttribute
 
 - Notable 2.0 payload differences:
   - Uses the `ATTRIBUTES` structure (container of `ATTRIBUTE` items) instead of 1.x `TEMPLATE_ATTRIBUTE`.
@@ -57,6 +63,7 @@ import (
 - Backward compatibility:
   - 1.x payloads remain the default; registering 2.0 payloads does not replace 1.4 payloads.
   - Decoding/encoding chooses payloads based on the `ProtocolVersion` in the KMIP header.
+  - For some operations (e.g., Get, ReKey, Add/Modify/Delete Attribute), KMIP 2.0 reuses the 1.x payload structures; `kmip20` registers factories to select those under 2.0.
 
 Minimal example (KMIP 2.0 Create)
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ go-kmip
 [![Documentation](https://godoc.org/github.com/smira/go-kmip?status.svg)](http://godoc.org/github.com/smira/go-kmip)
 [![Go Report Card](https://goreportcard.com/badge/github.com/smira/go-kmip)](https://goreportcard.com/report/github.com/smira/go-kmip)
 
-go-kmip implements subset of [KMIP 1.4](http://docs.oasis-open.org/kmip/spec/v1.4/os/kmip-spec-v1.4-os.html) protocol.
+go-kmip implements a subset of the [KMIP 1.4](http://docs.oasis-open.org/kmip/spec/v1.4/os/kmip-spec-v1.4-os.html) and [KMIP 2.0](https://docs.oasis-open.org/kmip/spec/v2.0/os/kmip-spec-v2.0-os.html) protocols.
 
 Basic TTLV encoding/decoding is fully implemented, as well as the basic client/server operations. 
 Other operations and fields could be implemented by adding required Go structures with KMIP tags.
@@ -27,6 +27,69 @@ any number of requests over the connection.
 
 This package doesn't implement any actual key processing or management - it's outside
 the scope of this package.
+
+KMIP 2.0 support
+----------------
+
+This branch adds initial KMIP 2.0 payload support alongside the existing 1.x implementation.
+
+- A new subpackage `kmip20` registers KMIP 2.0 request/response payloads at init-time.
+- Import it for side effects to enable 2.0 encoding/decoding:
+
+```go
+import (
+    "github.com/akeylesslabs/go-kmip"
+    _ "github.com/akeylesslabs/go-kmip/kmip20" // register KMIP 2.0 payloads
+)
+```
+
+- Currently covered KMIP 2.0 operations:
+  - Create
+  - CreateKeyPair
+  - Register
+  - Locate
+  - SetAttribute
+
+- Notable 2.0 payload differences:
+  - Uses the `ATTRIBUTES` structure (container of `ATTRIBUTE` items) instead of 1.x `TEMPLATE_ATTRIBUTE`.
+  - `CreateKeyPair` accepts `COMMON_ATTRIBUTES`, `PRIVATE_KEY_ATTRIBUTES`, `PUBLIC_KEY_ATTRIBUTES`.
+
+- Backward compatibility:
+  - 1.x payloads remain the default; registering 2.0 payloads does not replace 1.4 payloads.
+  - Decoding/encoding chooses payloads based on the `ProtocolVersion` in the KMIP header.
+
+Minimal example (KMIP 2.0 Create)
+---------------------------------
+
+```go
+package main
+
+import (
+    "bytes"
+    "github.com/akeylesslabs/go-kmip"
+    "github.com/akeylesslabs/go-kmip/kmip20"
+)
+
+func main() {
+    req := kmip.Request{
+        Header: kmip.RequestHeader{ // build header with KMIP 2.0
+            Version:    kmip.ProtocolVersion{Major: 2, Minor: 0},
+            BatchCount: 1,
+        },
+        BatchItems: []kmip.RequestBatchItem{
+            {
+                Operation: kmip.OPERATION_CREATE,
+                RequestPayload: kmip20.CreateRequest{
+                    ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY,
+                    Attributes: kmip20.Attributes{},
+                },
+            },
+        },
+    }
+    var buf bytes.Buffer
+    _ = kmip.NewEncoder(&buf).Encode(req)
+}
+```
 
 License
 -------

--- a/decode.go
+++ b/decode.go
@@ -22,7 +22,8 @@ type Decoder struct {
 	r io.Reader
 	s io.ByteScanner
 
-	lastTag Tag
+	lastTag         Tag
+	protocolVersion ProtocolVersion
 }
 
 // NewDecoder builds Decoder which reads from r
@@ -261,6 +262,13 @@ func (d *Decoder) decodeValue(f field, t reflect.Type, ff reflect.Value) (n int,
 				return d.decodeValue(f, t, ff)
 			}
 
+			if batchItem, ok := vv.Interface().(*RequestBatchItem); ok {
+				batchItem.protocolVersion = d.protocolVersion
+			}
+			if batchItem, ok := vv.Interface().(*ResponseBatchItem); ok {
+				batchItem.protocolVersion = d.protocolVersion
+			}
+
 			sD, err = getStructDesc(vv.Type().Elem())
 			if err != nil {
 				return
@@ -273,6 +281,12 @@ func (d *Decoder) decodeValue(f field, t reflect.Type, ff reflect.Value) (n int,
 			}
 
 			vv = reflect.New(t)
+			if batchItem, ok := vv.Interface().(*RequestBatchItem); ok {
+				batchItem.protocolVersion = d.protocolVersion
+			}
+			if batchItem, ok := vv.Interface().(*ResponseBatchItem); ok {
+				batchItem.protocolVersion = d.protocolVersion
+			}
 		}
 
 		sD.tag = f.tag
@@ -281,6 +295,13 @@ func (d *Decoder) decodeValue(f field, t reflect.Type, ff reflect.Value) (n int,
 		// invoke post-decode hook on this decoded struct
 		if h, ok := vv.Interface().(AfterUnmarshalKMIP); ok {
 			h.AfterUnmarshalKMIP()
+		}
+
+		if batchItem, ok := vv.Interface().(*RequestBatchItem); ok {
+			batchItem.protocolVersion = ProtocolVersion{}
+		}
+		if batchItem, ok := vv.Interface().(*ResponseBatchItem); ok {
+			batchItem.protocolVersion = ProtocolVersion{}
 		}
 
 		v = vv.Elem().Interface()
@@ -315,6 +336,7 @@ func (d *Decoder) decode(rv reflect.Value, structD *structDesc) (n int, err erro
 
 	// initialize wrapped decoder with limited reader
 	dd := NewDecoder(io.LimitReader(d.r, int64(expectedLen)))
+	dd.protocolVersion = d.protocolVersion
 
 	for _, f := range structD.fields {
 		var tag Tag
@@ -383,6 +405,13 @@ func (d *Decoder) decode(rv reflect.Value, structD *structDesc) (n int, err erro
 
 			if !f.skip {
 				ff.Set(reflect.ValueOf(v))
+			}
+
+			if h, ok := v.(RequestHeader); ok {
+				dd.protocolVersion = h.Version
+			}
+			if h, ok := v.(ResponseHeader); ok {
+				dd.protocolVersion = h.Version
 			}
 		}
 	}

--- a/kmip20/doc.go
+++ b/kmip20/doc.go
@@ -1,0 +1,5 @@
+// Package kmip20 adds KMIP 2.0 payload registrations for go-kmip.
+//
+// Import this package to register KMIP 2.0 request and response payload
+// structs, then configure a Server or Client with ProtocolVersion.
+package kmip20

--- a/kmip20/encode_decode_test.go
+++ b/kmip20/encode_decode_test.go
@@ -1,0 +1,199 @@
+package kmip20
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/akeylesslabs/go-kmip"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKMIP20_EncodeDecode_Create_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_CREATE,
+				RequestPayload: CreateRequest{
+					ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY,
+					Attributes: Attributes{},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, CreateRequest{}, decoded.BatchItems[0].RequestPayload)
+	cr := decoded.BatchItems[0].RequestPayload.(CreateRequest)
+	require.Equal(t, kmip.OBJECT_TYPE_SYMMETRIC_KEY, cr.ObjectType)
+}
+
+func TestKMIP20_EncodeDecode_Create_Response(t *testing.T) {
+	resp := kmip.Response{
+		Header: kmip.ResponseHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.ResponseBatchItem{
+			{
+				Operation:       kmip.OPERATION_CREATE,
+				ResultStatus:    kmip.RESULT_STATUS_SUCCESS,
+				ResponsePayload: CreateResponse{ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY, UniqueIdentifier: "id"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(resp))
+
+	var decoded kmip.Response
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, CreateResponse{}, decoded.BatchItems[0].ResponsePayload)
+	cr := decoded.BatchItems[0].ResponsePayload.(CreateResponse)
+	require.Equal(t, kmip.OBJECT_TYPE_SYMMETRIC_KEY, cr.ObjectType)
+	require.Equal(t, "id", cr.UniqueIdentifier)
+}
+
+func TestKMIP20_EncodeDecode_CreateKeyPair_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_CREATE_KEY_PAIR,
+				RequestPayload: CreateKeyPairRequest{
+					CommonAttributes: Attributes{
+						Values: kmip.Attributes{
+							{
+								Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM,
+								Value: kmip.CRYPTO_RSA,
+							},
+							{
+								Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_LENGTH,
+								Value: int32(2048),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, CreateKeyPairRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_Register_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_REGISTER,
+				RequestPayload: RegisterRequest{
+					ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY,
+					Attributes: Attributes{
+						Values: kmip.Attributes{
+							{
+								Name:  kmip.ATTRIBUTE_NAME_NAME,
+								Value: kmip.Name{Value: "name", Type: kmip.NAME_TYPE_UNINTERPRETED_TEXT_STRING},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, RegisterRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_Locate_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_LOCATE,
+				RequestPayload: LocateRequest{
+					MaximumItems: 1,
+					Attributes: Attributes{
+						Values: kmip.Attributes{
+							{
+								Name:  kmip.ATTRIBUTE_NAME_OBJECT_TYPE,
+								Value: kmip.OBJECT_TYPE_SYMMETRIC_KEY,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, LocateRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_SetAttribute_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_SET_ATTRIBUTE,
+				RequestPayload: SetAttributeRequest{
+					UniqueIdentifier: "uid",
+					NewAttribute: kmip.Attribute{
+						Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM,
+						Value: kmip.CRYPTO_AES,
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, SetAttributeRequest{}, decoded.BatchItems[0].RequestPayload)
+	sar := decoded.BatchItems[0].RequestPayload.(SetAttributeRequest)
+	require.Equal(t, "uid", sar.UniqueIdentifier)
+	require.Equal(t, kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM, sar.NewAttribute.Name)
+}
+

--- a/kmip20/encode_decode_test.go
+++ b/kmip20/encode_decode_test.go
@@ -390,3 +390,108 @@ func TestKMIP20_EncodeDecode_AdjustAttribute_Response(t *testing.T) {
 	ar := decoded.BatchItems[0].ResponsePayload.(AdjustAttributeResponse)
 	require.Equal(t, "uid", ar.UniqueIdentifier)
 }
+
+func TestKMIP20_EncodeDecode_Request_MultipleBatchItems(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 2,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_CREATE,
+				RequestPayload: CreateRequest{
+					ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY,
+					Attributes: Attributes{
+						Values: kmip.Attributes{
+							{Name: kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM, Value: kmip.CRYPTO_AES},
+							{Name: kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_LENGTH, Value: int32(256)},
+						},
+					},
+				},
+			},
+			{
+				Operation: kmip.OPERATION_SET_ATTRIBUTE,
+				RequestPayload: SetAttributeRequest{
+					UniqueIdentifier: "uid",
+					NewAttribute: kmip.Attribute{
+						Name:  kmip.ATTRIBUTE_NAME_NAME,
+						Value: kmip.Name{Value: "n", Type: kmip.NAME_TYPE_UNINTERPRETED_TEXT_STRING},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 2)
+	require.IsType(t, CreateRequest{}, decoded.BatchItems[0].RequestPayload)
+	require.IsType(t, SetAttributeRequest{}, decoded.BatchItems[1].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_Response_MultipleBatchItems(t *testing.T) {
+	resp := kmip.Response{
+		Header: kmip.ResponseHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 2,
+		},
+		BatchItems: []kmip.ResponseBatchItem{
+			{
+				Operation:       kmip.OPERATION_CREATE,
+				ResultStatus:    kmip.RESULT_STATUS_SUCCESS,
+				ResponsePayload: CreateResponse{ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY, UniqueIdentifier: "id1"},
+			},
+			{
+				Operation:       kmip.OPERATION_SET_ATTRIBUTE,
+				ResultStatus:    kmip.RESULT_STATUS_SUCCESS,
+				ResponsePayload: SetAttributeResponse{UniqueIdentifier: "id2"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(resp))
+
+	var decoded kmip.Response
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 2)
+	require.IsType(t, CreateResponse{}, decoded.BatchItems[0].ResponsePayload)
+	require.IsType(t, SetAttributeResponse{}, decoded.BatchItems[1].ResponsePayload)
+}
+
+func TestKMIP14_EncodeDecode_UsesV1Payloads_WithKMIP20Registered(t *testing.T) {
+	// Ensure kmip20 is imported and factories are registered
+	_ = ProtocolVersion
+
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    kmip.ProtocolVersion{Major: 1, Minor: 4},
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_CREATE,
+				RequestPayload: kmip.CreateRequest{
+					ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY,
+					TemplateAttribute: kmip.TemplateAttribute{
+						Attributes: kmip.Attributes{
+							{Name: kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM, Value: kmip.CRYPTO_AES},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, kmip.CreateRequest{}, decoded.BatchItems[0].RequestPayload)
+}

--- a/kmip20/encode_decode_test.go
+++ b/kmip20/encode_decode_test.go
@@ -196,4 +196,3 @@ func TestKMIP20_EncodeDecode_SetAttribute_Request(t *testing.T) {
 	require.Equal(t, "uid", sar.UniqueIdentifier)
 	require.Equal(t, kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM, sar.NewAttribute.Name)
 }
-

--- a/kmip20/encode_decode_test.go
+++ b/kmip20/encode_decode_test.go
@@ -196,3 +196,197 @@ func TestKMIP20_EncodeDecode_SetAttribute_Request(t *testing.T) {
 	require.Equal(t, "uid", sar.UniqueIdentifier)
 	require.Equal(t, kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM, sar.NewAttribute.Name)
 }
+
+func TestKMIP20_EncodeDecode_Get_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_GET,
+				RequestPayload: kmip.GetRequest{
+					UniqueIdentifier: "49a1ca88-6bea-4fb2-b450-7e58802c3038",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, kmip.GetRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_ReKey_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_REKEY,
+				RequestPayload: kmip.ReKeyRequest{
+					UniqueIdentifier: "49a1ca88-6bea-4fb2-b450-7e58802c3038",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, kmip.ReKeyRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_AddAttribute_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_ADD_ATTRIBUTE,
+				RequestPayload: kmip.AddAttributeRequest{
+					UniqueIdentifier: "49a1ca88-6bea-4fb2-b450-7e58802c3038",
+					Attribute: kmip.Attribute{
+						Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM,
+						Value: kmip.CRYPTO_AES,
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, kmip.AddAttributeRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_ModifyAttribute_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_MODIFY_ATTRIBUTE,
+				RequestPayload: kmip.ModifyAttributeRequest{
+					UniqueIdentifier: "49a1ca88-6bea-4fb2-b450-7e58802c3038",
+					Attribute: kmip.Attribute{
+						Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM,
+						Value: kmip.CRYPTO_AES,
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, kmip.ModifyAttributeRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_DeleteAttribute_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_DELETE_ATTRIBUTE,
+				RequestPayload: kmip.DeleteAttributeRequest{
+					UniqueIdentifier: "49a1ca88-6bea-4fb2-b450-7e58802c3038",
+					AttributeName:    "x-customAttribute",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, kmip.DeleteAttributeRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestKMIP20_EncodeDecode_AdjustAttribute_Request(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_ADJUST_ATTRIBUTE,
+				RequestPayload: AdjustAttributeRequest{
+					UniqueIdentifier: "uid",
+					AttributeRef: AttributeReference{
+						Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_LENGTH,
+						Index: 0,
+					},
+					AdjustmentType:  kmip.Enum(1),
+					AdjustmentValue: 32,
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, AdjustAttributeRequest{}, decoded.BatchItems[0].RequestPayload)
+	ar := decoded.BatchItems[0].RequestPayload.(AdjustAttributeRequest)
+	require.Equal(t, "uid", ar.UniqueIdentifier)
+	require.Equal(t, kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_LENGTH, ar.AttributeRef.Name)
+}
+
+func TestKMIP20_EncodeDecode_AdjustAttribute_Response(t *testing.T) {
+	resp := kmip.Response{
+		Header: kmip.ResponseHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.ResponseBatchItem{
+			{
+				Operation:       kmip.OPERATION_ADJUST_ATTRIBUTE,
+				ResultStatus:    kmip.RESULT_STATUS_SUCCESS,
+				ResponsePayload: AdjustAttributeResponse{UniqueIdentifier: "uid"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(resp))
+
+	var decoded kmip.Response
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, AdjustAttributeResponse{}, decoded.BatchItems[0].ResponsePayload)
+	ar := decoded.BatchItems[0].ResponsePayload.(AdjustAttributeResponse)
+	require.Equal(t, "uid", ar.UniqueIdentifier)
+}

--- a/kmip20/payloads.go
+++ b/kmip20/payloads.go
@@ -174,12 +174,12 @@ type AttributeReference struct {
 
 // AdjustAttributeRequest is the KMIP 2.0 Adjust Attribute request payload.
 type AdjustAttributeRequest struct {
-	UniqueIdentifier  string             `kmip:"UNIQUE_IDENTIFIER"`
-	AttributeRef      AttributeReference `kmip:"ATTRIBUTE_REFERENCE,required"`
-	AdjustmentType    kmip.Enum          `kmip:"ADJUSTMENT_TYPE,required"`
-	AdjustmentValue   int32              `kmip:"ADJUSTMENT_VALUE"`
-	CurrentAttribute  kmip.Attribute     `kmip:"CURRENT_ATTRIBUTE"`
-	NewAttribute      kmip.Attribute     `kmip:"NEW_ATTRIBUTE"`
+	UniqueIdentifier string             `kmip:"UNIQUE_IDENTIFIER"`
+	AttributeRef     AttributeReference `kmip:"ATTRIBUTE_REFERENCE,required"`
+	AdjustmentType   kmip.Enum          `kmip:"ADJUSTMENT_TYPE,required"`
+	AdjustmentValue  int32              `kmip:"ADJUSTMENT_VALUE"`
+	CurrentAttribute kmip.Attribute     `kmip:"CURRENT_ATTRIBUTE"`
+	NewAttribute     kmip.Attribute     `kmip:"NEW_ATTRIBUTE"`
 }
 
 // AdjustAttributeResponse is the KMIP 2.0 Adjust Attribute response payload.

--- a/kmip20/payloads.go
+++ b/kmip20/payloads.go
@@ -17,11 +17,32 @@ func registerRequestPayloads() {
 	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_CREATE_KEY_PAIR, func() interface{} {
 		return &CreateKeyPairRequest{}
 	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_GET, func() interface{} {
+		// KMIP 2.0 Get payload is compatible with 1.x structure
+		return &kmip.GetRequest{}
+	})
 	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_REGISTER, func() interface{} {
 		return &RegisterRequest{}
 	})
 	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_LOCATE, func() interface{} {
 		return &LocateRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_REKEY, func() interface{} {
+		// KMIP 2.0 ReKey payload remains compatible with 1.x structure
+		return &kmip.ReKeyRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_ADD_ATTRIBUTE, func() interface{} {
+		// Though KMIP 2.0 introduces SetAttribute/AdjustAttribute, AddAttribute can still be handled
+		return &kmip.AddAttributeRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_MODIFY_ATTRIBUTE, func() interface{} {
+		return &kmip.ModifyAttributeRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_DELETE_ATTRIBUTE, func() interface{} {
+		return &kmip.DeleteAttributeRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_ADJUST_ATTRIBUTE, func() interface{} {
+		return &AdjustAttributeRequest{}
 	})
 	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_SET_ATTRIBUTE, func() interface{} {
 		return &SetAttributeRequest{}
@@ -35,11 +56,29 @@ func registerResponsePayloads() {
 	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_CREATE_KEY_PAIR, func() interface{} {
 		return &CreateKeyPairResponse{}
 	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_GET, func() interface{} {
+		return &kmip.GetResponse{}
+	})
 	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_REGISTER, func() interface{} {
 		return &RegisterResponse{}
 	})
 	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_LOCATE, func() interface{} {
 		return &LocateResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_REKEY, func() interface{} {
+		return &kmip.ReKeyResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_ADD_ATTRIBUTE, func() interface{} {
+		return &kmip.AddAttributeResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_MODIFY_ATTRIBUTE, func() interface{} {
+		return &kmip.ModifyAttributeResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_DELETE_ATTRIBUTE, func() interface{} {
+		return &kmip.DeleteAttributeResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_ADJUST_ATTRIBUTE, func() interface{} {
+		return &AdjustAttributeResponse{}
 	})
 	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_SET_ATTRIBUTE, func() interface{} {
 		return &SetAttributeResponse{}
@@ -122,5 +161,28 @@ type SetAttributeRequest struct {
 
 // SetAttributeResponse is the KMIP 2.0 Set Attribute response payload.
 type SetAttributeResponse struct {
+	UniqueIdentifier string `kmip:"UNIQUE_IDENTIFIER,required"`
+}
+
+// AttributeReference is the KMIP 2.0 Attribute Reference structure.
+type AttributeReference struct {
+	kmip.Tag `kmip:"ATTRIBUTE_REFERENCE"`
+
+	Name  string `kmip:"ATTRIBUTE_NAME,required"`
+	Index int32  `kmip:"ATTRIBUTE_INDEX"`
+}
+
+// AdjustAttributeRequest is the KMIP 2.0 Adjust Attribute request payload.
+type AdjustAttributeRequest struct {
+	UniqueIdentifier  string             `kmip:"UNIQUE_IDENTIFIER"`
+	AttributeRef      AttributeReference `kmip:"ATTRIBUTE_REFERENCE,required"`
+	AdjustmentType    kmip.Enum          `kmip:"ADJUSTMENT_TYPE,required"`
+	AdjustmentValue   int32              `kmip:"ADJUSTMENT_VALUE"`
+	CurrentAttribute  kmip.Attribute     `kmip:"CURRENT_ATTRIBUTE"`
+	NewAttribute      kmip.Attribute     `kmip:"NEW_ATTRIBUTE"`
+}
+
+// AdjustAttributeResponse is the KMIP 2.0 Adjust Attribute response payload.
+type AdjustAttributeResponse struct {
 	UniqueIdentifier string `kmip:"UNIQUE_IDENTIFIER,required"`
 }

--- a/kmip20/payloads.go
+++ b/kmip20/payloads.go
@@ -1,0 +1,126 @@
+package kmip20
+
+import "github.com/akeylesslabs/go-kmip"
+
+// ProtocolVersion is the KMIP 2.0 protocol version.
+var ProtocolVersion = kmip.ProtocolVersion{Major: 2, Minor: 0}
+
+func init() {
+	registerRequestPayloads()
+	registerResponsePayloads()
+}
+
+func registerRequestPayloads() {
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_CREATE, func() interface{} {
+		return &CreateRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_CREATE_KEY_PAIR, func() interface{} {
+		return &CreateKeyPairRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_REGISTER, func() interface{} {
+		return &RegisterRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_LOCATE, func() interface{} {
+		return &LocateRequest{}
+	})
+	kmip.RegisterRequestPayloadFactory(ProtocolVersion, kmip.OPERATION_SET_ATTRIBUTE, func() interface{} {
+		return &SetAttributeRequest{}
+	})
+}
+
+func registerResponsePayloads() {
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_CREATE, func() interface{} {
+		return &CreateResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_CREATE_KEY_PAIR, func() interface{} {
+		return &CreateKeyPairResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_REGISTER, func() interface{} {
+		return &RegisterResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_LOCATE, func() interface{} {
+		return &LocateResponse{}
+	})
+	kmip.RegisterResponsePayloadFactory(ProtocolVersion, kmip.OPERATION_SET_ATTRIBUTE, func() interface{} {
+		return &SetAttributeResponse{}
+	})
+}
+
+// Attributes is the KMIP 2.0 Attributes structure.
+type Attributes struct {
+	kmip.Tag `kmip:"ATTRIBUTES"`
+
+	Values kmip.Attributes `kmip:"ATTRIBUTE"`
+}
+
+// CreateRequest is the KMIP 2.0 Create request payload.
+type CreateRequest struct {
+	ObjectType             kmip.Enum  `kmip:"OBJECT_TYPE,required"`
+	Attributes             Attributes `kmip:"ATTRIBUTES,required"`
+	ProtectionStorageMasks kmip.Enum  `kmip:"PROTECTION_STORAGE_MASKS"`
+}
+
+// CreateResponse is the KMIP 2.0 Create response payload.
+type CreateResponse struct {
+	ObjectType       kmip.Enum `kmip:"OBJECT_TYPE,required"`
+	UniqueIdentifier string    `kmip:"UNIQUE_IDENTIFIER,required"`
+}
+
+// CreateKeyPairRequest is the KMIP 2.0 Create Key Pair request payload.
+type CreateKeyPairRequest struct {
+	CommonAttributes                 Attributes `kmip:"COMMON_ATTRIBUTES"`
+	PrivateKeyAttributes             Attributes `kmip:"PRIVATE_KEY_ATTRIBUTES"`
+	PublicKeyAttributes              Attributes `kmip:"PUBLIC_KEY_ATTRIBUTES"`
+	CommonProtectionStorageMasks     kmip.Enum  `kmip:"PROTECTION_STORAGE_MASKS"`
+	PrivateKeyProtectionStorageMasks kmip.Enum  `kmip:"PROTECTION_STORAGE_MASKS"`
+	PublicKeyProtectionStorageMasks  kmip.Enum  `kmip:"PROTECTION_STORAGE_MASKS"`
+}
+
+// CreateKeyPairResponse is the KMIP 2.0 Create Key Pair response payload.
+type CreateKeyPairResponse struct {
+	PrivateKeyUniqueIdentifier string `kmip:"PRIVATE_KEY_UNIQUE_IDENTIFIER,required"`
+	PublicKeyUniqueIdentifier  string `kmip:"PUBLIC_KEY_UNIQUE_IDENTIFIER,required"`
+}
+
+// RegisterRequest is the KMIP 2.0 Register request payload.
+type RegisterRequest struct {
+	ObjectType kmip.Enum  `kmip:"OBJECT_TYPE,required"`
+	Attributes Attributes `kmip:"ATTRIBUTES,required"`
+
+	SymmetricKey kmip.SymmetricKey `kmip:"SYMMETRIC_KEY"`
+	PrivateKey   kmip.PrivateKey   `kmip:"PRIVATE_KEY"`
+	PublicKey    kmip.PublicKey    `kmip:"PUBLIC_KEY"`
+	Certificate  kmip.Certificate  `kmip:"CERTIFICATE"`
+	OpaqueObject kmip.OpaqueObject `kmip:"OPAQUE_OBJECT"`
+}
+
+// RegisterResponse is the KMIP 2.0 Register response payload.
+type RegisterResponse struct {
+	UniqueIdentifier string `kmip:"UNIQUE_IDENTIFIER,required"`
+}
+
+// LocateRequest is the KMIP 2.0 Locate request payload.
+type LocateRequest struct {
+	MaximumItems      int32      `kmip:"MAXIMUM_ITEMS"`
+	OffsetItems       int32      `kmip:"OFFSET_ITEMS"`
+	StorageStatusMask int32      `kmip:"STORAGE_STATUS_MASK"`
+	ObjectGroupMember kmip.Enum  `kmip:"OBJECT_GROUP_MEMBER"`
+	Attributes        Attributes `kmip:"ATTRIBUTES"`
+}
+
+// LocateResponse is the KMIP 2.0 Locate response payload.
+type LocateResponse struct {
+	LocatedItems      int32    `kmip:"LOCATED_ITEMS"`
+	UniqueIdentifiers []string `kmip:"UNIQUE_IDENTIFIER"`
+}
+
+// SetAttributeRequest is the KMIP 2.0 Set Attribute request payload.
+type SetAttributeRequest struct {
+	UniqueIdentifier string         `kmip:"UNIQUE_IDENTIFIER"`
+	NewAttribute     kmip.Attribute `kmip:"NEW_ATTRIBUTE,required"`
+}
+
+// SetAttributeResponse is the KMIP 2.0 Set Attribute response payload.
+type SetAttributeResponse struct {
+	UniqueIdentifier string `kmip:"UNIQUE_IDENTIFIER,required"`
+}

--- a/kmip20/payloads_test.go
+++ b/kmip20/payloads_test.go
@@ -73,3 +73,39 @@ func TestDecodeResponseUsesKMIP20PayloadForKMIP20Version(t *testing.T) {
 	require.Len(t, decoded.BatchItems, 1)
 	require.IsType(t, CreateResponse{}, decoded.BatchItems[0].ResponsePayload)
 }
+
+func TestAttributes_EncodeDecode(t *testing.T) {
+	attrs := Attributes{
+		Values: kmip.Attributes{
+			{
+				Name: kmip.ATTRIBUTE_NAME_NAME,
+				Value: kmip.Name{
+					Value: "obj",
+					Type:  kmip.NAME_TYPE_UNINTERPRETED_TEXT_STRING,
+				},
+			},
+			{
+				Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM,
+				Value: kmip.CRYPTO_AES,
+			},
+			{
+				Name:  kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_LENGTH,
+				Value: int32(256),
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(attrs))
+
+	var decoded Attributes
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+
+	require.Len(t, decoded.Values, 3)
+	require.Equal(t, kmip.ATTRIBUTE_NAME_NAME, decoded.Values[0].Name)
+	require.IsType(t, kmip.Name{}, decoded.Values[0].Value)
+	require.Equal(t, kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_ALGORITHM, decoded.Values[1].Name)
+	require.Equal(t, kmip.CRYPTO_AES, decoded.Values[1].Value)
+	require.Equal(t, kmip.ATTRIBUTE_NAME_CRYPTOGRAPHIC_LENGTH, decoded.Values[2].Name)
+	require.Equal(t, int32(256), decoded.Values[2].Value)
+}

--- a/kmip20/payloads_test.go
+++ b/kmip20/payloads_test.go
@@ -1,0 +1,75 @@
+package kmip20
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/akeylesslabs/go-kmip"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadRegistration(t *testing.T) {
+	reqPayload, err := kmip.NewRequestPayload(ProtocolVersion, kmip.OPERATION_CREATE)
+	require.NoError(t, err)
+	require.IsType(t, &CreateRequest{}, reqPayload)
+
+	respPayload, err := kmip.NewResponsePayload(ProtocolVersion, kmip.OPERATION_CREATE)
+	require.NoError(t, err)
+	require.IsType(t, &CreateResponse{}, respPayload)
+}
+
+func TestPayloadRegistrationDoesNotReplaceDefaultPayloads(t *testing.T) {
+	reqPayload, err := kmip.NewRequestPayload(kmip.ProtocolVersion{Major: 1, Minor: 4}, kmip.OPERATION_CREATE)
+	require.NoError(t, err)
+	require.IsType(t, &kmip.CreateRequest{}, reqPayload)
+}
+
+func TestDecodeRequestUsesKMIP20PayloadForKMIP20Version(t *testing.T) {
+	req := kmip.Request{
+		Header: kmip.RequestHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.RequestBatchItem{
+			{
+				Operation: kmip.OPERATION_CREATE,
+				RequestPayload: CreateRequest{
+					ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY,
+					Attributes: Attributes{},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(req))
+
+	var decoded kmip.Request
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, CreateRequest{}, decoded.BatchItems[0].RequestPayload)
+}
+
+func TestDecodeResponseUsesKMIP20PayloadForKMIP20Version(t *testing.T) {
+	resp := kmip.Response{
+		Header: kmip.ResponseHeader{
+			Version:    ProtocolVersion,
+			BatchCount: 1,
+		},
+		BatchItems: []kmip.ResponseBatchItem{
+			{
+				Operation:       kmip.OPERATION_CREATE,
+				ResultStatus:    kmip.RESULT_STATUS_SUCCESS,
+				ResponsePayload: CreateResponse{ObjectType: kmip.OBJECT_TYPE_SYMMETRIC_KEY, UniqueIdentifier: "id"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, kmip.NewEncoder(&buf).Encode(resp))
+
+	var decoded kmip.Response
+	require.NoError(t, kmip.NewDecoder(&buf).Decode(&decoded))
+	require.Len(t, decoded.BatchItems, 1)
+	require.IsType(t, CreateResponse{}, decoded.BatchItems[0].ResponsePayload)
+}

--- a/payload_registry.go
+++ b/payload_registry.go
@@ -26,6 +26,10 @@ func RegisterRequestPayloadFactory(version ProtocolVersion, operation Enum, fact
 	payloadFactoriesMu.Lock()
 	defer payloadFactoriesMu.Unlock()
 
+	if factory == nil {
+		panic(errors.Errorf("nil PayloadFactory for version=%v operation=%v", version, operation))
+	}
+
 	requestPayloadFactories[payloadFactoryKey{version: version, operation: operation}] = factory
 }
 
@@ -34,6 +38,10 @@ func RegisterRequestPayloadFactory(version ProtocolVersion, operation Enum, fact
 func RegisterResponsePayloadFactory(version ProtocolVersion, operation Enum, factory PayloadFactory) {
 	payloadFactoriesMu.Lock()
 	defer payloadFactoriesMu.Unlock()
+
+	if factory == nil {
+		panic(errors.Errorf("nil PayloadFactory for version=%v operation=%v", version, operation))
+	}
 
 	responsePayloadFactories[payloadFactoryKey{version: version, operation: operation}] = factory
 }
@@ -45,7 +53,11 @@ func NewRequestPayload(version ProtocolVersion, operation Enum) (interface{}, er
 	payloadFactoriesMu.RLock()
 	if factory, ok := requestPayloadFactories[payloadFactoryKey{version: version, operation: operation}]; ok {
 		payloadFactoriesMu.RUnlock()
-		return factory(), nil
+		v := factory()
+		if v == nil {
+			return nil, errors.Errorf("request payload factory returned nil for version=%v operation=%v", version, operation)
+		}
+		return v, nil
 	}
 	payloadFactoriesMu.RUnlock()
 
@@ -98,7 +110,11 @@ func NewResponsePayload(version ProtocolVersion, operation Enum) (interface{}, e
 	payloadFactoriesMu.RLock()
 	if factory, ok := responsePayloadFactories[payloadFactoryKey{version: version, operation: operation}]; ok {
 		payloadFactoriesMu.RUnlock()
-		return factory(), nil
+		v := factory()
+		if v == nil {
+			return nil, errors.Errorf("response payload factory returned nil for version=%v operation=%v", version, operation)
+		}
+		return v, nil
 	}
 	payloadFactoriesMu.RUnlock()
 

--- a/payload_registry.go
+++ b/payload_registry.go
@@ -1,0 +1,147 @@
+package kmip
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+// PayloadFactory builds an operation-specific request or response payload.
+type PayloadFactory func() interface{}
+
+type payloadFactoryKey struct {
+	version   ProtocolVersion
+	operation Enum
+}
+
+var (
+	payloadFactoriesMu       sync.RWMutex
+	requestPayloadFactories  = make(map[payloadFactoryKey]PayloadFactory)
+	responsePayloadFactories = make(map[payloadFactoryKey]PayloadFactory)
+)
+
+// RegisterRequestPayloadFactory registers a version-specific request payload
+// builder. It is intended for extension packages such as kmip20.
+func RegisterRequestPayloadFactory(version ProtocolVersion, operation Enum, factory PayloadFactory) {
+	payloadFactoriesMu.Lock()
+	defer payloadFactoriesMu.Unlock()
+
+	requestPayloadFactories[payloadFactoryKey{version: version, operation: operation}] = factory
+}
+
+// RegisterResponsePayloadFactory registers a version-specific response payload
+// builder. It is intended for extension packages such as kmip20.
+func RegisterResponsePayloadFactory(version ProtocolVersion, operation Enum, factory PayloadFactory) {
+	payloadFactoriesMu.Lock()
+	defer payloadFactoriesMu.Unlock()
+
+	responsePayloadFactories[payloadFactoryKey{version: version, operation: operation}] = factory
+}
+
+// NewRequestPayload builds the request payload type for a KMIP version and
+// operation. It falls back to the existing KMIP 1.x payloads when no
+// version-specific factory is registered.
+func NewRequestPayload(version ProtocolVersion, operation Enum) (interface{}, error) {
+	payloadFactoriesMu.RLock()
+	if factory, ok := requestPayloadFactories[payloadFactoryKey{version: version, operation: operation}]; ok {
+		payloadFactoriesMu.RUnlock()
+		return factory(), nil
+	}
+	payloadFactoriesMu.RUnlock()
+
+	switch operation {
+	case OPERATION_CREATE:
+		return &CreateRequest{}, nil
+	case OPERATION_CREATE_KEY_PAIR:
+		return &CreateKeyPairRequest{}, nil
+	case OPERATION_GET:
+		return &GetRequest{}, nil
+	case OPERATION_GET_ATTRIBUTES:
+		return &GetAttributesRequest{}, nil
+	case OPERATION_GET_ATTRIBUTE_LIST:
+		return &GetAttributeListRequest{}, nil
+	case OPERATION_DESTROY:
+		return &DestroyRequest{}, nil
+	case OPERATION_DISCOVER_VERSIONS:
+		return &DiscoverVersionsRequest{}, nil
+	case OPERATION_REGISTER:
+		return &RegisterRequest{}, nil
+	case OPERATION_ACTIVATE:
+		return &ActivateRequest{}, nil
+	case OPERATION_LOCATE:
+		return &LocateRequest{}, nil
+	case OPERATION_REVOKE:
+		return &RevokeRequest{}, nil
+	case OPERATION_REKEY:
+		return &ReKeyRequest{}, nil
+	case OPERATION_DECRYPT:
+		return &DecryptRequest{}, nil
+	case OPERATION_ENCRYPT:
+		return &EncryptRequest{}, nil
+	case OPERATION_QUERY:
+		return &QueryRequest{}, nil
+	case OPERATION_ADD_ATTRIBUTE:
+		return &AddAttributeRequest{}, nil
+	case OPERATION_MODIFY_ATTRIBUTE:
+		return &ModifyAttributeRequest{}, nil
+	case OPERATION_DELETE_ATTRIBUTE:
+		return &DeleteAttributeRequest{}, nil
+	default:
+		return nil, errors.Errorf("unsupported operation: %v", operation)
+	}
+}
+
+// NewResponsePayload builds the response payload type for a KMIP version and
+// operation. It falls back to the existing KMIP 1.x payloads when no
+// version-specific factory is registered.
+func NewResponsePayload(version ProtocolVersion, operation Enum) (interface{}, error) {
+	payloadFactoriesMu.RLock()
+	if factory, ok := responsePayloadFactories[payloadFactoryKey{version: version, operation: operation}]; ok {
+		payloadFactoriesMu.RUnlock()
+		return factory(), nil
+	}
+	payloadFactoriesMu.RUnlock()
+
+	switch operation {
+	case OPERATION_CREATE:
+		return &CreateResponse{}, nil
+	case OPERATION_CREATE_KEY_PAIR:
+		return &CreateKeyPairResponse{}, nil
+	case OPERATION_GET:
+		return &GetResponse{}, nil
+	case OPERATION_GET_ATTRIBUTES:
+		return &GetAttributesResponse{}, nil
+	case OPERATION_GET_ATTRIBUTE_LIST:
+		return &GetAttributeListResponse{}, nil
+	case OPERATION_ACTIVATE:
+		return &ActivateResponse{}, nil
+	case OPERATION_REVOKE:
+		return &RevokeResponse{}, nil
+	case OPERATION_DESTROY:
+		return &DestroyResponse{}, nil
+	case OPERATION_DISCOVER_VERSIONS:
+		return &DiscoverVersionsResponse{}, nil
+	case OPERATION_ENCRYPT:
+		return &EncryptResponse{}, nil
+	case OPERATION_DECRYPT:
+		return &DecryptResponse{}, nil
+	case OPERATION_SIGN:
+		return &SignResponse{}, nil
+	case OPERATION_REGISTER:
+		return &RegisterResponse{}, nil
+	case OPERATION_LOCATE:
+		return &LocateResponse{}, nil
+	case OPERATION_REKEY:
+		return &ReKeyResponse{}, nil
+	case OPERATION_QUERY:
+		return &QueryResponse{}, nil
+	case OPERATION_ADD_ATTRIBUTE:
+		return &AddAttributeResponse{}, nil
+	case OPERATION_MODIFY_ATTRIBUTE:
+		return &ModifyAttributeResponse{}, nil
+	case OPERATION_DELETE_ATTRIBUTE:
+		return &DeleteAttributeResponse{}, nil
+	default:
+		return nil, errors.Errorf("unsupported operation: %v", operation)
+	}
+}

--- a/request.go
+++ b/request.go
@@ -4,11 +4,7 @@ package kmip
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import (
-	"time"
-
-	"github.com/pkg/errors"
-)
+import "time"
 
 // Request is a Request Message Structure
 type Request struct {
@@ -45,52 +41,13 @@ type RequestBatchItem struct {
 	UniqueID         []byte           `kmip:"UNIQUE_BATCH_ITEM_ID"`
 	RequestPayload   interface{}      `kmip:"REQUEST_PAYLOAD,required"`
 	MessageExtension MessageExtension `kmip:"MESSAGE_EXTENSION"`
+
+	protocolVersion ProtocolVersion
 }
 
 // BuildFieldValue builds value for RequestPayload based on Operation
 func (bi *RequestBatchItem) BuildFieldValue(name string) (v interface{}, err error) {
-	switch bi.Operation {
-	case OPERATION_CREATE:
-		v = &CreateRequest{}
-	case OPERATION_CREATE_KEY_PAIR:
-		v = &CreateKeyPairRequest{}
-	case OPERATION_GET:
-		v = &GetRequest{}
-	case OPERATION_GET_ATTRIBUTES:
-		v = &GetAttributesRequest{}
-	case OPERATION_GET_ATTRIBUTE_LIST:
-		v = &GetAttributeListRequest{}
-	case OPERATION_DESTROY:
-		v = &DestroyRequest{}
-	case OPERATION_DISCOVER_VERSIONS:
-		v = &DiscoverVersionsRequest{}
-	case OPERATION_REGISTER:
-		v = &RegisterRequest{}
-	case OPERATION_ACTIVATE:
-		v = &ActivateRequest{}
-	case OPERATION_LOCATE:
-		v = &LocateRequest{}
-	case OPERATION_REVOKE:
-		v = &RevokeRequest{}
-	case OPERATION_REKEY:
-		v = &ReKeyRequest{}
-	case OPERATION_DECRYPT:
-		v = &DecryptRequest{}
-	case OPERATION_ENCRYPT:
-		v = &EncryptRequest{}
-	case OPERATION_QUERY:
-		v = &QueryRequest{}
-	case OPERATION_ADD_ATTRIBUTE:
-		v = &AddAttributeRequest{}
-	case OPERATION_MODIFY_ATTRIBUTE:
-		v = &ModifyAttributeRequest{}
-	case OPERATION_DELETE_ATTRIBUTE:
-		v = &DeleteAttributeRequest{}
-	default:
-		err = errors.Errorf("unsupported operation: %v", bi.Operation)
-	}
-
-	return
+	return NewRequestPayload(bi.protocolVersion, bi.Operation)
 }
 
 // ProtocolVersion is a Protocol Version structure

--- a/response.go
+++ b/response.go
@@ -4,11 +4,7 @@ package kmip
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import (
-	"time"
-
-	"github.com/pkg/errors"
-)
+import "time"
 
 // Response is a Response Message Structure
 type Response struct {
@@ -41,54 +37,13 @@ type ResponseBatchItem struct {
 	AsyncronousCorrelationValue []byte           `kmip:"ASYNCHRONOUS_CORRELATION_VALUE"`
 	ResponsePayload             interface{}      `kmip:"RESPONSE_PAYLOAD"`
 	MessageExtension            MessageExtension `kmip:"MESSAGE_EXTENSION"`
+
+	protocolVersion ProtocolVersion
 }
 
 // BuildFieldValue builds value for ResponsePayload based on Operation
 func (bi *ResponseBatchItem) BuildFieldValue(name string) (v interface{}, err error) {
-	switch bi.Operation {
-	case OPERATION_CREATE:
-		v = &CreateResponse{}
-	case OPERATION_CREATE_KEY_PAIR:
-		v = &CreateKeyPairResponse{}
-	case OPERATION_GET:
-		v = &GetResponse{}
-	case OPERATION_GET_ATTRIBUTES:
-		v = &GetAttributesResponse{}
-	case OPERATION_GET_ATTRIBUTE_LIST:
-		v = &GetAttributeListResponse{}
-	case OPERATION_ACTIVATE:
-		v = &ActivateResponse{}
-	case OPERATION_REVOKE:
-		v = &RevokeResponse{}
-	case OPERATION_DESTROY:
-		v = &DestroyResponse{}
-	case OPERATION_DISCOVER_VERSIONS:
-		v = &DiscoverVersionsResponse{}
-	case OPERATION_ENCRYPT:
-		v = &EncryptResponse{}
-	case OPERATION_DECRYPT:
-		v = &DecryptResponse{}
-	case OPERATION_SIGN:
-		v = &SignResponse{}
-	case OPERATION_REGISTER:
-		v = &RegisterResponse{}
-	case OPERATION_LOCATE:
-		v = &LocateResponse{}
-	case OPERATION_REKEY:
-		v = &ReKeyResponse{}
-	case OPERATION_QUERY:
-		v = &QueryResponse{}
-	case OPERATION_ADD_ATTRIBUTE:
-		v = &AddAttributeResponse{}
-	case OPERATION_MODIFY_ATTRIBUTE:
-		v = &ModifyAttributeResponse{}
-	case OPERATION_DELETE_ATTRIBUTE:
-		v = &DeleteAttributeResponse{}
-	default:
-		err = errors.Errorf("unsupported operation: %v", bi.Operation)
-	}
-
-	return
+	return NewResponsePayload(bi.protocolVersion, bi.Operation)
 }
 
 // Nonce object is a structure used by the server to send a random value to the client

--- a/server_test.go
+++ b/server_test.go
@@ -11,10 +11,12 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -118,6 +120,25 @@ func (s *ServerSuite) TestDiscoverVersions() {
 	s.Require().Equal([]ProtocolVersion(nil), versions)
 }
 
+func TestDiscoverVersionsCanAdvertiseKMIP20WhenConfigured(t *testing.T) {
+	server := &Server{
+		SupportedVersions: []ProtocolVersion{
+			{Major: 2, Minor: 0},
+			{Major: 1, Minor: 4},
+		},
+	}
+
+	resp, err := server.handleDiscoverVersions(&RequestContext{}, &RequestBatchItem{
+		RequestPayload: DiscoverVersionsRequest{
+			ProtocolVersions: []ProtocolVersion{{Major: 2, Minor: 0}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, DiscoverVersionsResponse{
+		ProtocolVersions: []ProtocolVersion{{Major: 2, Minor: 0}},
+	}, resp)
+}
+
 func (s *ServerSuite) TestSessionAuthHandlerOkay() {
 	s.server.SessionAuthHandler = func(conn net.Conn) (interface{}, error) {
 		commonName := conn.(*tls.Conn).ConnectionState().PeerCertificates[0].Subject.CommonName
@@ -186,8 +207,14 @@ func (s *ServerSuite) TestConnectTLSNoCA() {
 		s.client.TLSConfig.RootCAs = savedPool
 	}()
 
-	s.Require().Error(errors.Cause(s.client.Connect()))
-	s.Require().Contains(errors.Cause(s.client.Connect()).Error(), "x509: certificate signed by unknown authority")
+	err := errors.Cause(s.client.Connect())
+	s.Require().Error(err)
+	s.Require().True(
+		strings.Contains(err.Error(), "x509: certificate signed by unknown authority") ||
+			strings.Contains(err.Error(), "certificate is not trusted"),
+		"unexpected certificate error: %s",
+		err,
+	)
 }
 
 func (s *ServerSuite) TestOperationGenericFail() {


### PR DESCRIPTION
Introduce version-aware payload factories and a kmip20 package so callers can register KMIP 2.0 payload shapes without changing existing KMIP 1.x defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KMIP 2.0 support added for many operations with new 2.0 payload types.
  * Runtime payload registry now selects request/response payloads by KMIP protocol version.
  * Decoder preserves protocol version across nested decoding to ensure consistent payload selection.
  * Server discovery can advertise KMIP 2.0 when configured.

* **Tests**
  * Expanded unit and round‑trip encode/decode tests covering KMIP 2.0 registration, selection, and roundtrips.

* **Documentation**
  * README and package docs updated with KMIP 2.0 usage and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akeylesslabs/go-kmip/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->